### PR TITLE
Patch getCursorOffset to match textarea.js

### DIFF
--- a/src/textcomplete.contenteditable.js
+++ b/src/textcomplete.contenteditable.js
@@ -63,7 +63,7 @@ export default class extends Editor {
     const top = rangeRects.top - docRects.top + lineHeight
     return this.el.dir !== "rtl"
       ? { left, lineHeight, top }
-      : { right: left, lineHeight, top }
+      : { right: document.documentElement.clientWidth - left, lineHeight, top }
   }
 
   getBeforeCursor() {


### PR DESCRIPTION
Hello @yuku, as per your own PR to introduce RTL support here: yuku/textcomplete@c3972b30e2f686cde36f20eb1551175ea2bc9e17

It looks like the value of `right` is not correctly calculated, causing the cursor position to be calculated incorrectly on RTL directionality and thus the dropdown is off-screen. I've matched the logic to subtract `left` from the document width as is done in `textarea.js`.