### PR TITLE
Update peerDependencies constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "webpack-merge": "^4.1.0"
   },
   "peerDependencies": {
-    "textcomplete": "^0.14.2"
+    "textcomplete": "^0.x"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Hi again,

Yarn outputs this warning on install:
`warning " > textcomplete.contenteditable@0.1.1" has incorrect peer dependency "textcomplete@^0.14.2".`

https://jubianchi.github.io/semver-check/#/^0.14.2/0.17.1

As I don't forsee any breaking changes until v1.0 (or ever, if you don't intend on releasing v1.0 of textcomplete), I just relaxed the constraint all the way down to the whole `0.x` release window.